### PR TITLE
Add "parametrize" decision to style guide

### DIFF
--- a/Writing/StyleGuide.md
+++ b/Writing/StyleGuide.md
@@ -18,6 +18,7 @@ But some issues are worth addressing specifically within the group because they 
 - “Atom type”, not “atomtype”
 - “Dataset”, not “data set”, when used as a description of a particular entity, such as “we collected this dataset to allow validation of…”
 - “Force field”, not “forcefield”
+- "Parametrize", not "parameterize"
 - “Predicting”, resist the temptation to use when calculating values which you know. Sometimes acceptable to use for values which have already been measured but are blind to you (e.g. in the context of a blind challenge), but best used for values which have not yet been measured. Use “calculating”, “estimating”, or “computing” if comparing to literature values.
 - “Side chain” not “side-chain”
 - “Underestimate”/”Overestimate”: Only use for quantities where this has a clear and obvious meaning. Don’t use it for binding free energies, where “underestimate” can refer to the magnitude (so “underestimated” means “binds too weakly”) or the value (so “underestimated” means “binds too strongly”). A similar concern applies to Kd values. Just say something direct, like “the computed binding free energy was too favorable”.


### PR DESCRIPTION
As discussed on Slack, let's standardize our spelling of this word to "parametrize". "Parameterize", "parameterise", and "parametrise" are all arguably correct but let's be consistent. "Parametrize" was chosen for consistency with [PyTest](https://docs.pytest.org/en/6.2.x/parametrize.html).